### PR TITLE
Fixing persona hover from recent MSFT update

### DIFF
--- a/src/webparts/spContactCard/components/SPFXPeopleCard/SPFxPeopleCard.tsx
+++ b/src/webparts/spContactCard/components/SPFXPeopleCard/SPFxPeopleCard.tsx
@@ -118,6 +118,7 @@ export default class SPFxPeopleCard extends React.PureComponent<IPeopleCardProps
             },
             serviceScope: this.props.serviceScope,
             upn: this.props.email,
+            legacyUpn: this.props.email,
             onCardOpen: () => {
                 if(this.props.onCardOpenCallback){
                     this.props.onCardOpenCallback();


### PR DESCRIPTION
Per PnP running into the same issue, https://github.com/pnp/sp-dev-fx-controls-react/issues/1241, adding legacyUpn to createElement props